### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/custom_op/user_ops/CMakeLists.txt
+++ b/custom_op/user_ops/CMakeLists.txt
@@ -16,7 +16,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SSE_FLAGS} -march=native -fopenmp -D_G
 set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -fPIC --shared -D_GLIBCXX_USE_CXX11_ABI=${TensorFlow_ABI}" )
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11  --expt-relaxed-constexpr -D GOOGLE_CUDA=1 --gpu-architecture=sm_52 -D_GLIBCXX_USE_CXX11_ABI=${TensorFlow_ABI}" )
 
-include_directories(SYSTEM "${CUDA_INCLUDE_DIRS}/../../")
+get_filename_component(TF_CUDA ${CUDA_INCLUDE_DIRS} DIRECTORY)
+get_filename_component(TF_CUDA ${TF_CUDA} DIRECTORY)
+include_directories(SYSTEM ${TF_CUDA})
 include_directories(SYSTEM ${TensorFlow_INCLUDE_DIR})
 include_directories(SYSTEM "kernels")
 


### PR DESCRIPTION
Some systems (I know of 2) have the `include` dir as a symlink, where `..` would resolve to something else that totally doesn't contain the `cuda` dir. The proposed way should work better in that case!
```
$ ls -al /opt/cuda/include
lrwxrwxrwx 1 root root 28 Mar  1 16:45 /opt/cuda/include -> targets/x86_64-linux/include
```